### PR TITLE
General code quality fix-1

### DIFF
--- a/alipay-api/src/main/java/me/hao0/alipay/model/AlipayFields.java
+++ b/alipay-api/src/main/java/me/hao0/alipay/model/AlipayFields.java
@@ -12,6 +12,10 @@ import java.util.List;
  */
 public class AlipayFields {
 
+    private AlipayFields() {
+        
+    }
+    
     /**
      * PC支付服务器通知参数
      */

--- a/alipay-core/src/main/java/me/hao0/alipay/core/Refunds.java
+++ b/alipay-core/src/main/java/me/hao0/alipay/core/Refunds.java
@@ -82,7 +82,7 @@ public class Refunds extends Component {
         // 退款明细
         List<RefundDetailData> detailDatas = refundDetail.getDetailDatas();
         checkNotNullAndEmpty(detailDatas, "detail datas");
-        refundParams.put(AlipayField.BATCH_NUM.field(), detailDatas.size() + "");
+        refundParams.put(AlipayField.BATCH_NUM.field(), Integer.toString(detailDatas.size()));
         refundParams.put(AlipayField.DETAIL_DATA.field(), refundDetail.formatDetailDatas());
 
         // md5签名参数


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1118 - Utility classes should not have public constructors.
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed
